### PR TITLE
docs: add color-coded maintenance status legend

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ This is a list of different projects that use OpenShock in some way!
 
 Have a finished (or even work in progress but generally working) project you'd like to see on this list? [Submit an issue to this repo and let us know!](https://github.com/OpenShock/awesome-openshock/issues)
 
+## Maintenance Legend
+
+- 🟢 Official project maintained by the OpenShock team
+- 🟡 Community-maintained project
+- 🔴 Deprecated or unmaintained project
+
 ## Community Links
 
 - [OpenShock Discord Server](https://discord.gg/OpenShock)
@@ -11,130 +17,130 @@ Have a finished (or even work in progress but generally working) project you'd l
 
 ## OpenShock Desktop
 
-- [OpenShock Desktop](https://github.com/OpenShock/Desktop) - Main cross-platform client for controlling OpenShock devices.
+- 🟢 [OpenShock Desktop](https://github.com/OpenShock/Desktop) - Main cross-platform client for controlling OpenShock devices.
   - Maintained by the OpenShock team
 
 ### Modules
 
-- [ShockOSC](https://github.com/OpenShock/ShockOSC) - Interface for OpenShock with OSC/OscQuery applications like VRChat.
+- 🟢 [ShockOSC](https://github.com/OpenShock/ShockOSC) - Interface for OpenShock with OSC/OscQuery applications like VRChat.
   - Maintained by the OpenShock team
-- [LocalRelay](https://github.com/OpenShock/LocalRelay) - Sends shock commands over serial
+- 🟢 [LocalRelay](https://github.com/OpenShock/LocalRelay) - Sends shock commands over serial
   - Maintained by the OpenShock team
-- [OpenShock Sentry](https://github.com/OpenShock/Sentry) - Uses computer vision and OCR to detect in-game text and trigger shocks.
+- 🟢 [OpenShock Sentry](https://github.com/OpenShock/Sentry) - Uses computer vision and OCR to detect in-game text and trigger shocks.
   - Maintained by the OpenShock team
 
 ## Applications
 
-- [OpenShock VROverlay](https://github.com/OpenShock/VROverlay) - OpenVR overlay that displays shock events in VR.
+- 🟢 [OpenShock VROverlay](https://github.com/OpenShock/VROverlay) - OpenVR overlay that displays shock events in VR.
   - Maintained by the OpenShock team
-- [ShockAlarm](https://github.com/ComputerElite/ShockAlarmApp) - Feature-rich alternative frontend for mobile, web and Linux.
+- 🟡 [ShockAlarm](https://github.com/ComputerElite/ShockAlarmApp) - Feature-rich alternative frontend for mobile, web and Linux.
   - Created by [ComputerElite](https://github.com/ComputerElite/)
-- [3DShock](https://github.com/ComputerElite/3DShock) - Nintendo 3DS homebrew client for controlling OpenShock devices.
+- 🟡 [3DShock](https://github.com/ComputerElite/3DShock) - Nintendo 3DS homebrew client for controlling OpenShock devices.
   - Created by [ComputerElite](https://github.com/ComputerElite)
-- [ProfanityShock](https://github.com/Quatumus/ProfanityShock) - Voice recogniztion profanity detector.
+- 🟡 [ProfanityShock](https://github.com/Quatumus/ProfanityShock) - Voice recogniztion profanity detector.
   - Created by [Quatumus](https://github.com/Quatumus)
 
 ### Stream Integration
 
-- [TipLink](https://tiplink.dev/#pricing) - No-code platform for stream-triggered shocks and automation.
+- 🟡 [TipLink](https://tiplink.dev/#pricing) - No-code platform for stream-triggered shocks and automation.
   - Created by [Boba Tea Dev](https://bobatea.dev)
-- [HybridShock](https://gist.github.com/Python727/7b2bdea59be4d8a1a88c7b93ba992928) - Real-time feedback system where chat triggers vibrations, shocks and sounds.
+- 🟡 [HybridShock](https://gist.github.com/Python727/7b2bdea59be4d8a1a88c7b93ba992928) - Real-time feedback system where chat triggers vibrations, shocks and sounds.
   - Created by [Python727](https://github.com/Python727)
 
 ### Bots
 
-- [OpenShockTelegramBot](https://github.com/DexFolf/OpenShockTelegramBot) - Telegram bot for controlling OpenShock devices.
+- 🟡 [OpenShockTelegramBot](https://github.com/DexFolf/OpenShockTelegramBot) - Telegram bot for controlling OpenShock devices.
   - Created by [DexFolf](https://github.com/DexFolf)
 
 ## Game Integrations
 
 ### Multi-game
 
-- [DeathDetect](https://gitlab.com/Kubuxu/deathdetect) - Detects player deaths in various games and sends shocks.
+- 🟡 [DeathDetect](https://gitlab.com/Kubuxu/deathdetect) - Detects player deaths in various games and sends shocks.
   - Created by [Kubuxu](https://gitlab.com/Kubuxu)
 
 ### Final Fantasy XIV
 
-- [WoLightning](https://github.com/TheHeadpatCat/WoLightning) - Plugin that delivers shocks based on FFXIV events.
+- 🟡 [WoLightning](https://github.com/TheHeadpatCat/WoLightning) - Plugin that delivers shocks based on FFXIV events.
   - Created by [TheHeadpatCat](https://github.com/TheHeadpatCat)
 
 ### Minecraft
 
-- [OpenShock Minecraft](https://github.com/OpenShock/Integrations.Minecraft) - Mod that shocks players based on Minecraft events.
+- 🟢 [OpenShock Minecraft](https://github.com/OpenShock/Integrations.Minecraft) - Mod that shocks players based on Minecraft events.
   - Maintained by the OpenShock team
 
 ### Beat Saber
 
-- [PainSaber](https://github.com/miterosan/PainSaber) - Beat Saber mod that shocks when you miss notes.
+- 🟡 [PainSaber](https://github.com/miterosan/PainSaber) - Beat Saber mod that shocks when you miss notes.
   - Created by [Miterosan](https://github.com/miterosan)
 
 ### Lethal Company
 
-- [OpenShock LethalCompany](https://github.com/OpenShock/Integrations.LethalCompany) - Lethal Company integration to shock players.
+- 🟢 [OpenShock LethalCompany](https://github.com/OpenShock/Integrations.LethalCompany) - Lethal Company integration to shock players.
   - Maintained by the OpenShock team
 
 ### The Binding of Isaac
 
-- [ShockedIsaac](https://github.com/miterosan/ShockedIsaac) - Mod that shocks when Isaac takes damage.
+- 🟡 [ShockedIsaac](https://github.com/miterosan/ShockedIsaac) - Mod that shocks when Isaac takes damage.
   - Created by [Miterosan](https://github.com/miterosan)
 
 ### Geometry Dash
 
-- [OpenShock-GD](https://github.com/JaydenTheNardo/OpenShock-GD) - Geometry Dash integration for shock feedback.
+- 🟡 [OpenShock-GD](https://github.com/JaydenTheNardo/OpenShock-GD) - Geometry Dash integration for shock feedback.
   - Created by [JaydenTheNardo](https://github.com/JaydenTheNardo)
 
 ### Balatro
 
-- [OpenShockBalatro](https://github.com/LostQuasar/OpenShockBalatro) - Balatro mod that shocks based on card game events.
+- 🟡 [OpenShockBalatro](https://github.com/LostQuasar/OpenShockBalatro) - Balatro mod that shocks based on card game events.
   - Created by [LostQuasar](https://github.com/LostQuasar)
 
 ### Celeste
 
-- [OpenshockCeleste](https://github.com/Pandaptable/openshock-celeste) - Celeste mod that shocks on player deaths.
+- 🟡 [OpenshockCeleste](https://github.com/Pandaptable/openshock-celeste) - Celeste mod that shocks on player deaths.
   - Created by [Pandaptable](https://github.com/Pandaptable)
 
 ### R.E.P.O.
 
-- [ReOpenShock](https://github.com/lillithkt/ReOpenShock) - R.E.P.O. integration for shock feedback.
+- 🟡 [ReOpenShock](https://github.com/lillithkt/ReOpenShock) - R.E.P.O. integration for shock feedback.
   - Created by [Lillith](https://github.com/lillithkt)
 
 ## Game Assets
 
-- [ZenithVal's ShockOSC Remote](https://zenithval.booth.pm/items/6531509) - VRChat remote prefab for triggering shocks.
+- 🟡 [ZenithVal's ShockOSC Remote](https://zenithval.booth.pm/items/6531509) - VRChat remote prefab for triggering shocks.
   - Created by [ZenithVal](https://github.com/ZenithVal)
-- [Liindy's Shock Collar](https://liindy.gumroad.com/l/Shock) - VRChat shock collar asset.
+- 🟡 [Liindy's Shock Collar](https://liindy.gumroad.com/l/Shock) - VRChat shock collar asset.
   - Created by [Liindy](https://liindy.gumroad.com)
-- [Kyobinoyo's ShockOSC Remote Trigger Prefab](https://kyobinoyo.gumroad.com/l/xhxukh) - VRChat remote trigger prefab.
+- 🟡 [Kyobinoyo's ShockOSC Remote Trigger Prefab](https://kyobinoyo.gumroad.com/l/xhxukh) - VRChat remote trigger prefab.
   - Created by [Kyobinoyo](https://kyobinoyo.gumroad.com)
-- [Kyobinoyo's Shocker Model Prefab](https://kyobinoyo.gumroad.com/l/idkbu) - Shocker model for VRChat avatars.
+- 🟡 [Kyobinoyo's Shocker Model Prefab](https://kyobinoyo.gumroad.com/l/idkbu) - Shocker model for VRChat avatars.
   - Created by [Kyobinoyo](https://kyobinoyo.gumroad.com)
-- [LiaWare's Shock Button](https://liaware.gumroad.com/l/shock-button) (also on [Jinxxy](https://jinxxy.com/LiaWare/shock-button) and [Booth](https://liaware.booth.pm/items/6961602)) - Shock collar asset that randomizes shock strength when poked.
+- 🟡 [LiaWare's Shock Button](https://liaware.gumroad.com/l/shock-button) (also on [Jinxxy](https://jinxxy.com/LiaWare/shock-button) and [Booth](https://liaware.booth.pm/items/6961602)) - Shock collar asset that randomizes shock strength when poked.
   - Created by [LiaWare](https://liaware.gumroad.com)
 
 ## Command Line utilities
 
-- [OpenShock TUI](https://github.com/LostQuasar/openshock-tui) - Terminal user interface for controlling OpenShock devices.
+- 🟡 [OpenShock TUI](https://github.com/LostQuasar/openshock-tui) - Terminal user interface for controlling OpenShock devices.
   - Created by [LostQuasar](https://github.com/LostQuasar)
 
 ## Libraries
 
 ### C#
 
-- [OpenShock SDK](https://github.com/OpenShock/SDK.CSharp) - C# SDK for building OpenShock integrations.
+- 🟢 [OpenShock SDK](https://github.com/OpenShock/SDK.CSharp) - C# SDK for building OpenShock integrations.
   - Maintained by the OpenShock team
 
 ### Rust
 
-- [rzap](https://github.com/LostQuasar/rzap) - Rust crate to interact with OpenShock API.
+- 🟡 [rzap](https://github.com/LostQuasar/rzap) - Rust crate to interact with OpenShock API.
   - Created by [LostQuasar](https://github.com/LostQuasar)
 
 ## 3D Printing
 
-- [OpenShock 3DPrints](https://github.com/OpenShock/3DPrints) - 3D-printable designs for OpenShock hardware.
+- 🟢 [OpenShock 3DPrints](https://github.com/OpenShock/3DPrints) - 3D-printable designs for OpenShock hardware.
   - Maintained by the OpenShock team
 
 ## Deprecated
 
-- [FanShock](https://bobadev.gumroad.com/l/fanshock) - Early tip-trigger app for streamers.
+- 🔴 [FanShock](https://bobadev.gumroad.com/l/fanshock) - Early tip-trigger app for streamers.
   - Created by [Boba Tea Dev](https://bobatea.dev)
   - Replaced by [TipLink](https://tiplink.dev/#pricing)


### PR DESCRIPTION
## Summary
- add maintenance legend with colored indicators
- tag each project with color-coded maintenance icons

## Testing
- `npm test` *(fails: package.json not found)*
- `pre-commit run --files README.md` *(fails: .pre-commit-config.yaml is not a file)*

------
https://chatgpt.com/codex/tasks/task_e_6891c91b10cc8327b2af547cb2b5ce9d